### PR TITLE
Allow installation with Laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "php": "^8.1",
     "guzzlehttp/guzzle": "^7.5",
-    "illuminate/support": "^10.0||^11.0",
+    "illuminate/support": "^10.0||^11.0||^12.0",
     "thewirecutter/paapi5-php-sdk": "^1.2"
   },
   "require-dev": {


### PR DESCRIPTION
Just adding `^12.0` as installable so it can be used with Laravel 12.